### PR TITLE
fix: low priority implicits etc

### DIFF
--- a/shared/src/main/scala/com/thoughtworks/Extractor.scala
+++ b/shared/src/main/scala/com/thoughtworks/Extractor.scala
@@ -1,18 +1,18 @@
 package com.thoughtworks
 
-private[thoughtworks] sealed trait LowPrirorityExtractor {
-
+private[thoughtworks] sealed trait LowPriorityExtractor {
+  
   sealed trait SeqExtractor[-A, +B] {
     def unapplySeq(a: A): Option[Seq[B]]
   }
-
-  implicit final class OptionFunctionToSeqExtractor[-A, +B] private[LowPrirorityExtractor](underlying: A => Option[Seq[B]]) {
+  
+  implicit final class OptionFunctionToSeqExtractor[-A, +B] private[LowPriorityExtractor](underlying: A => Option[Seq[B]]) {
     def extractSeq = new SeqExtractor[A, B] {
       def unapplySeq(a: A) = underlying(a)
     }
   }
 
-  implicit final class OptionFunctionToExtractor[-A, +B] private[LowPrirorityExtractor](underlying: A => Option[B]) {
+  implicit final class OptionFunctionToExtractor[-A, +B] private[LowPriorityExtractor](underlying: A => Option[B]) {
     def extract = new Extractor[A, B] {
       def unapply(a: A) = underlying(a)
     }
@@ -26,6 +26,7 @@ private[thoughtworks] sealed trait LowPrirorityExtractor {
 sealed trait Extractor[-A, +B] {
   def unapply(a: A): Option[B]
 }
+
 
 /**
   * Utilities to convert between `A => Option[B]`, `PartialFunction[A, B]` and [[Extractor]].
@@ -64,7 +65,7 @@ sealed trait Extractor[-A, +B] {
     }}}
   *
   */
-object Extractor extends LowPrirorityExtractor {
+object Extractor extends LowPriorityExtractor {
 
   implicit final class PartialFunctionToSeqExtractor[-A, +B] private[Extractor](underlying: PartialFunction[A, Seq[B]]) {
     def extractSeq = new SeqExtractor[A, B] {


### PR DESCRIPTION
Change:
- typo:  low`priority` extractor implicits

~~trait SeqExtractor moved to the same scope with trait Extractor. It makes more sense to put SeqExtractor outside LowPriorityExtractor(Implicits).~~
